### PR TITLE
Use vref instead of hardcoding ksp_versions

### DIFF
--- a/SETI-ProbeControlEnabler.netkan
+++ b/SETI-ProbeControlEnabler.netkan
@@ -1,11 +1,11 @@
 {
     "$kref" : "#/ckan/github/Y3mo/SETI-ProbeControlEnabler",
+    "$vref" : "#/ckan/ksp-avc",
     "spec_version" : 1,
     "name": "RemoteTech - SETI ProbeControlEnabler",
     "identifier": "SETI-ProbeControlEnabler",
     "abstract"     : "This SETI version of the ProbeControlEnabler retains the integrated omni antennas (SETIrebalance) for manned command pods. Probe core integrated omni antennas still do not work (needs changes to RemoteTech, see RemoteTech github issue tracker). It was inspired by the MM config from Felger.",
     "license"	: "GPL-2.0",
-    "ksp_version"  : "1.1.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/106130"
     },


### PR DESCRIPTION
With $vref set NetKAN will scrape ksp version compatibility from your .version file so that you don't have to duplicate your work.
